### PR TITLE
Include weather.js in Vite build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
+            input: ['resources/css/app.css', 'resources/js/app.js', 'resources/js/weather.js'],
             refresh: true,
         }),
         vue(),


### PR DESCRIPTION
## Summary
- include `resources/js/weather.js` as a Vite entry point
- rebuild frontend assets

## Testing
- `npm run build`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68741113f7e4832aadc21f3542909a90