### PR TITLE
Brno-focused weather logging

### DIFF
--- a/app/Models/WeatherLog.php
+++ b/app/Models/WeatherLog.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+class WeatherLog extends Model
+{
+    use HasUuids;
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     */
+    public $incrementing = false;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'id',
+        'temperature',
+        'humidity',
+        'wind_speed',
+        'pressure',
+        'precipitation',
+        'lat',
+        'lon',
+        'source',
+        'timestamp',
+    ];
+}

--- a/database/migrations/2025_07_13_210510_create_weather_logs_table.php
+++ b/database/migrations/2025_07_13_210510_create_weather_logs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('weather_logs', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->decimal('temperature', 5, 2);
+            $table->integer('humidity');
+            $table->decimal('wind_speed', 5, 2);
+            $table->integer('pressure');
+            $table->decimal('precipitation', 5, 2)->nullable();
+            $table->decimal('lat', 8, 5);
+            $table->decimal('lon', 8, 5);
+            $table->string('source', 50);
+            $table->dateTime('timestamp');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('weather_logs');
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -9,3 +9,9 @@
     --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
         'Segoe UI Symbol', 'Noto Color Emoji';
 }
+
+@layer base {
+    body {
+        @apply bg-gradient-to-br from-blue-50 via-sky-100 to-purple-100 min-h-screen;
+    }
+}

--- a/resources/js/components/WeatherApp.vue
+++ b/resources/js/components/WeatherApp.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex h-screen" id="app-root">
-    <aside class="w-80 bg-gray-100 p-4 overflow-y-auto space-y-4">
+    <aside class="w-80 bg-white/70 backdrop-blur p-4 overflow-y-auto space-y-4">
       <h1 class="text-xl font-bold mb-2">{{ trans.title }}</h1>
       <SearchLocation />
       <WeatherLayers />
@@ -9,6 +9,15 @@
         <p>{{ weather.weather[0].description }}</p>
         <p class="font-bold">{{ weather.main.temp }}°C</p>
       </div>
+      <div v-if="stats.temperature" class="text-sm space-y-1">
+        <h3 class="font-semibold">{{ trans.stats_last_24h }}</h3>
+        <p>Temp ⌀ {{ stats.temperature.toFixed(1) }}°C</p>
+        <p>{{ trans.humidity }} ⌀ {{ stats.humidity.toFixed(0) }}%</p>
+      </div>
+      <div v-if="prediction.temperature" class="text-sm space-y-1">
+        <h3 class="font-semibold">{{ trans.prediction_next }}</h3>
+        <p>{{ prediction.temperature.toFixed(1) }}°C</p>
+      </div>
     </aside>
     <MapView class="flex-1" />
   </div>
@@ -16,12 +25,22 @@
 
 <script setup>
 import { storeToRefs } from 'pinia';
+import { onMounted } from 'vue';
 import { useWeatherStore } from '../store/weather';
 import SearchLocation from './SearchLocation.vue';
 import WeatherLayers from './WeatherLayers.vue';
 import MapView from './MapView.vue';
 
 const store = useWeatherStore();
-const { current: weather } = storeToRefs(store);
+const { current: weather, stats, prediction } = storeToRefs(store);
 const trans = window.trans;
+
+onMounted(() => {
+  store.loadByCoords(49.1951, 16.6068);
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(pos => {
+      store.loadByCoords(pos.coords.latitude, pos.coords.longitude);
+    });
+  }
+});
 </script>

--- a/resources/js/store/weather.js
+++ b/resources/js/store/weather.js
@@ -1,11 +1,13 @@
 import { defineStore } from 'pinia';
-import { fetchWeather, fetchForecast, fetchCombined } from '../weather';
+import { fetchWeather, fetchForecast, fetchCombined, fetchStats, fetchPrediction } from '../weather';
 
 export const useWeatherStore = defineStore('weather', {
   state: () => ({
     current: null,
     forecast: [],
     combined: {},
+    stats: {},
+    prediction: {},
     layer: 'precipitation_new',
   }),
   actions: {
@@ -17,15 +19,25 @@ export const useWeatherStore = defineStore('weather', {
           lon: this.current.coord.lon,
         });
       }
+      await this.loadStats();
+      await this.loadPrediction();
     },
     async loadByCoords(lat, lon) {
       this.current = await fetchWeather({ lat, lon });
       if (this.current.coord) {
         this.forecast = await fetchForecast({ lat, lon });
       }
+      await this.loadStats();
+      await this.loadPrediction();
     },
     async loadCombined(lat, lon) {
       this.combined = await fetchCombined({ lat, lon });
+    },
+    async loadStats() {
+      this.stats = await fetchStats();
+    },
+    async loadPrediction() {
+      this.prediction = await fetchPrediction();
     },
     setLayer(l) {
       this.layer = l;

--- a/resources/js/weather.js
+++ b/resources/js/weather.js
@@ -24,6 +24,16 @@ export async function fetchCombined(params) {
     return res.json();
 }
 
+export async function fetchStats() {
+    const res = await fetch('/api/stats');
+    return res.json();
+}
+
+export async function fetchPrediction() {
+    const res = await fetch('/api/predict');
+    return res.json();
+}
+
 export async function initMap(lat, lon) {
     const mapDiv = document.getElementById('map');
     if (!map) {

--- a/resources/lang/cs/weather.php
+++ b/resources/lang/cs/weather.php
@@ -17,4 +17,6 @@ return [
     'layer_clouds' => 'Oblačnost',
     'layer_pressure' => 'Tlak',
     'layer_radar' => 'Srážkový radar',
+    'stats_last_24h' => 'Průměry za 24h',
+    'prediction_next' => 'Odhad na další hodinu',
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,3 +8,5 @@ Route::get('/', [WeatherController::class, 'index']);
 Route::get('/api/weather', [WeatherController::class, 'getWeather']);
 Route::get('/api/forecast', [WeatherController::class, 'getForecast']);
 Route::get('/api/combined', [WeatherController::class, 'combined']);
+Route::get('/api/stats', [WeatherController::class, 'stats']);
+Route::get('/api/predict', [WeatherController::class, 'predict']);

--- a/tests/Feature/StatsTest.php
+++ b/tests/Feature/StatsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\WeatherLog;
+
+class StatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_stats_returns_average(): void
+    {
+        WeatherLog::create([
+            'temperature' => 10,
+            'humidity' => 50,
+            'wind_speed' => 1,
+            'pressure' => 1010,
+            'precipitation' => 0,
+            'lat' => 49.1951,
+            'lon' => 16.6068,
+            'source' => 'test',
+            'timestamp' => now(),
+        ]);
+
+        $response = $this->get('/api/stats');
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/WeatherLoggingTest.php
+++ b/tests/Feature/WeatherLoggingTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+use App\Models\WeatherLog;
+
+class WeatherLoggingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_weather_endpoint_logs_data(): void
+    {
+        Http::fake([
+            'https://api.openweathermap.org/data/2.5/weather*' => Http::response([
+                'main' => ['temp' => 20, 'humidity' => 60, 'pressure' => 1000],
+                'wind' => ['speed' => 2],
+            ], 200),
+        ]);
+
+        $response = $this->get('/api/weather?lat=49.1951&lon=16.6068');
+        $response->assertStatus(200);
+        $this->assertDatabaseCount('weather_logs', 1);
+    }
+}


### PR DESCRIPTION
## Summary
- log every OpenWeatherMap fetch into `weather_logs`
- provide `/api/stats` and `/api/predict` endpoints for averages and simple forecast
- auto-load Brno weather on startup and use geolocation if allowed
- expose weather statistics and prediction in the sidebar
- modernise base styles
- add tests for logging and stats

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68741ecf16bc832a94df46ba5121f012