### PR TITLE
Add Brno weather logging and stats

### DIFF
--- a/app/Models/WeatherLog.php
+++ b/app/Models/WeatherLog.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+class WeatherLog extends Model
+{
+    use HasUuids;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'temperature',
+        'humidity',
+        'wind_speed',
+        'pressure',
+        'precipitation',
+        'lat',
+        'lon',
+        'source',
+        'timestamp',
+    ];
+}

--- a/database/migrations/2025_07_13_183007_create_weather_logs_table.php
+++ b/database/migrations/2025_07_13_183007_create_weather_logs_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('weather_logs', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->decimal('temperature', 5, 2)->nullable();
+            $table->integer('humidity')->nullable();
+            $table->decimal('wind_speed', 5, 2)->nullable();
+            $table->integer('pressure')->nullable();
+            $table->decimal('precipitation', 5, 2)->nullable();
+            $table->decimal('lat', 8, 5);
+            $table->decimal('lon', 8, 5);
+            $table->string('source', 50);
+            $table->timestamp('timestamp');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('weather_logs');
+    }
+};

--- a/resources/js/components/StatsPanel.vue
+++ b/resources/js/components/StatsPanel.vue
@@ -1,0 +1,18 @@
+<template>
+  <div v-if="stats" class="space-y-1">
+    <h2 class="font-semibold text-lg">{{ trans.stats_title }}</h2>
+    <p>{{ trans.stats_average }}: {{ stats.avg_temp }}°C</p>
+    <p>{{ trans.stats_min }}: {{ stats.min_temp }}°C</p>
+    <p>{{ trans.stats_max }}: {{ stats.max_temp }}°C</p>
+    <p>{{ trans.stats_predicted }}: {{ stats.predicted_temp }}°C</p>
+  </div>
+</template>
+
+<script setup>
+import { storeToRefs } from 'pinia';
+import { useWeatherStore } from '../store/weather';
+
+const store = useWeatherStore();
+const { stats } = storeToRefs(store);
+const trans = window.trans;
+</script>

--- a/resources/js/components/WeatherApp.vue
+++ b/resources/js/components/WeatherApp.vue
@@ -4,6 +4,7 @@
       <h1 class="text-xl font-bold mb-2">{{ trans.title }}</h1>
       <SearchLocation />
       <WeatherLayers />
+      <StatsPanel />
       <div v-if="weather" class="space-y-1">
         <h2 class="font-semibold text-lg">{{ weather.name }}</h2>
         <p>{{ weather.weather[0].description }}</p>
@@ -20,8 +21,21 @@ import { useWeatherStore } from '../store/weather';
 import SearchLocation from './SearchLocation.vue';
 import WeatherLayers from './WeatherLayers.vue';
 import MapView from './MapView.vue';
+import StatsPanel from './StatsPanel.vue';
+import { onMounted } from 'vue';
 
 const store = useWeatherStore();
 const { current: weather } = storeToRefs(store);
 const trans = window.trans;
+
+onMounted(() => {
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(
+      pos => store.loadByCoords(pos.coords.latitude, pos.coords.longitude),
+      () => store.loadByCoords(49.1951, 16.6068)
+    );
+  } else {
+    store.loadByCoords(49.1951, 16.6068);
+  }
+});
 </script>

--- a/resources/js/store/weather.js
+++ b/resources/js/store/weather.js
@@ -1,11 +1,12 @@
 import { defineStore } from 'pinia';
-import { fetchWeather, fetchForecast, fetchCombined } from '../weather';
+import { fetchWeather, fetchForecast, fetchCombined, fetchStats } from '../weather';
 
 export const useWeatherStore = defineStore('weather', {
   state: () => ({
     current: null,
     forecast: [],
     combined: {},
+    stats: null,
     layer: 'precipitation_new',
   }),
   actions: {
@@ -16,12 +17,14 @@ export const useWeatherStore = defineStore('weather', {
           lat: this.current.coord.lat,
           lon: this.current.coord.lon,
         });
+        this.stats = await fetchStats({});
       }
     },
     async loadByCoords(lat, lon) {
       this.current = await fetchWeather({ lat, lon });
       if (this.current.coord) {
         this.forecast = await fetchForecast({ lat, lon });
+        this.stats = await fetchStats({});
       }
     },
     async loadCombined(lat, lon) {
@@ -29,6 +32,9 @@ export const useWeatherStore = defineStore('weather', {
     },
     setLayer(l) {
       this.layer = l;
+    },
+    async loadStats(period = 7) {
+      this.stats = await fetchStats({ period });
     },
   },
 });

--- a/resources/js/weather.js
+++ b/resources/js/weather.js
@@ -24,6 +24,12 @@ export async function fetchCombined(params) {
     return res.json();
 }
 
+export async function fetchStats(params) {
+    const query = new URLSearchParams(params);
+    const res = await fetch(`/api/stats?${query}`);
+    return res.json();
+}
+
 export async function initMap(lat, lon) {
     const mapDiv = document.getElementById('map');
     if (!map) {

--- a/resources/lang/cs/weather.php
+++ b/resources/lang/cs/weather.php
@@ -17,4 +17,9 @@ return [
     'layer_clouds' => 'Oblačnost',
     'layer_pressure' => 'Tlak',
     'layer_radar' => 'Srážkový radar',
+    'stats_title' => 'Statistiky',
+    'stats_average' => 'Průměrná teplota',
+    'stats_min' => 'Minimální teplota',
+    'stats_max' => 'Maximální teplota',
+    'stats_predicted' => 'Předpověď',
 ];

--- a/resources/views/weather.blade.php
+++ b/resources/views/weather.blade.php
@@ -10,7 +10,7 @@
             height: 100%;
             margin: 0;
             font-family: var(--font-sans);
-            background: radial-gradient(circle at top left, #eef3ff, #cdd8f6);
+            background: linear-gradient(to bottom, #f0f4ff, #d9e4ff);
         }
     </style>
     @if (file_exists(public_path('build/manifest.json')) || file_exists(public_path('hot')))

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,3 +8,4 @@ Route::get('/', [WeatherController::class, 'index']);
 Route::get('/api/weather', [WeatherController::class, 'getWeather']);
 Route::get('/api/forecast', [WeatherController::class, 'getForecast']);
 Route::get('/api/combined', [WeatherController::class, 'combined']);
+Route::get('/api/stats', [WeatherController::class, 'stats']);

--- a/tests/Feature/StatsTest.php
+++ b/tests/Feature/StatsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\WeatherLog;
+use Illuminate\Support\Facades\Date;
+
+class StatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_stats_returns_data(): void
+    {
+        WeatherLog::create([
+            'temperature' => 10,
+            'humidity' => 80,
+            'wind_speed' => 1.2,
+            'pressure' => 1000,
+            'precipitation' => 0,
+            'lat' => 49.1951,
+            'lon' => 16.6068,
+            'source' => 'test',
+            'timestamp' => Date::now(),
+        ]);
+
+        $response = $this->getJson('/api/stats');
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['avg_temp','min_temp','max_temp','predicted_temp']);
+    }
+}


### PR DESCRIPTION
## Summary
- store weather data in new `weather_logs` table
- create `WeatherLog` model
- log current weather in `WeatherController`
- provide `/api/stats` endpoint for weather statistics
- show stats in frontend with new `StatsPanel` component
- load Brno weather by default on startup
- modernize landing page gradient
- add tests for stats endpoint

## Testing
- `composer install --no-interaction`
- `npm install`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68741ecf16bc832a94df46ba5121f012