### PR TITLE
Fix stats numeric output

### DIFF
--- a/app/Http/Controllers/WeatherController.php
+++ b/app/Http/Controllers/WeatherController.php
@@ -188,7 +188,17 @@ class WeatherController extends Controller
             ->selectRaw('AVG(temperature) as temperature, AVG(humidity) as humidity, AVG(wind_speed) as wind_speed, AVG(pressure) as pressure, AVG(precipitation) as precipitation')
             ->first();
 
-        return response()->json($avg ?? []);
+        if (!$avg) {
+            return response()->json([]);
+        }
+
+        return response()->json([
+            'temperature' => (float) $avg->temperature,
+            'humidity' => (float) $avg->humidity,
+            'wind_speed' => (float) $avg->wind_speed,
+            'pressure' => (float) $avg->pressure,
+            'precipitation' => (float) $avg->precipitation,
+        ]);
     }
 
     /**

--- a/tests/Feature/StatsTest.php
+++ b/tests/Feature/StatsTest.php
@@ -26,5 +26,12 @@ class StatsTest extends TestCase
 
         $response = $this->get('/api/stats');
         $response->assertStatus(200);
+        $response->assertExactJson([
+            'temperature' => 10.0,
+            'humidity' => 50.0,
+            'wind_speed' => 1.0,
+            'pressure' => 1010.0,
+            'precipitation' => 0.0,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- return float values from weather stats endpoint
- add test covering numeric stats

## Testing
- `php artisan test`
- `curl -s http://localhost:8000/api/stats`

------
https://chatgpt.com/codex/tasks/task_e_68742280bcc8832a8122ee332c070ac1