### PR TITLE
Add draggable dashboard with navigation

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\WeatherLog;
+use Carbon\Carbon;
+
+class DashboardController extends Controller
+{
+    public function summary()
+    {
+        $week = WeatherLog::where('timestamp', '>=', now()->subDays(7))
+            ->selectRaw('AVG(temperature) as temperature, AVG(humidity) as humidity, AVG(pressure) as pressure, AVG(wind_speed) as wind_speed, AVG(precipitation) as precipitation')
+            ->first();
+        $month = WeatherLog::where('timestamp', '>=', now()->subDays(30))
+            ->selectRaw('AVG(temperature) as temperature, AVG(humidity) as humidity, AVG(pressure) as pressure, AVG(wind_speed) as wind_speed, AVG(precipitation) as precipitation')
+            ->first();
+
+        return response()->json([
+            'week' => [
+                'temperature' => $week ? round((float) $week->temperature, 1) : null,
+                'humidity' => $week ? round((float) $week->humidity) : null,
+                'pressure' => $week ? round((float) $week->pressure) : null,
+                'wind_speed' => $week ? round((float) $week->wind_speed, 1) : null,
+                'precipitation' => $week ? round((float) $week->precipitation, 1) : null,
+            ],
+            'month' => [
+                'temperature' => $month ? round((float) $month->temperature, 1) : null,
+                'humidity' => $month ? round((float) $month->humidity) : null,
+                'pressure' => $month ? round((float) $month->pressure) : null,
+                'wind_speed' => $month ? round((float) $month->wind_speed, 1) : null,
+                'precipitation' => $month ? round((float) $month->precipitation, 1) : null,
+            ],
+        ]);
+    }
+
+    public function extremes()
+    {
+        $start = now()->subDays(30);
+        $maxTemp = WeatherLog::where('timestamp', '>=', $start)->orderByDesc('temperature')->first();
+        $minTemp = WeatherLog::where('timestamp', '>=', $start)->orderBy('temperature')->first();
+        $maxHumidity = WeatherLog::where('timestamp', '>=', $start)->orderByDesc('humidity')->first();
+        $minHumidity = WeatherLog::where('timestamp', '>=', $start)->orderBy('humidity')->first();
+
+        return response()->json([
+            'max_temperature' => $maxTemp ? ['value' => $maxTemp->temperature, 'time' => $maxTemp->timestamp] : null,
+            'min_temperature' => $minTemp ? ['value' => $minTemp->temperature, 'time' => $minTemp->timestamp] : null,
+            'max_humidity' => $maxHumidity ? ['value' => $maxHumidity->humidity, 'time' => $maxHumidity->timestamp] : null,
+            'min_humidity' => $minHumidity ? ['value' => $minHumidity->humidity, 'time' => $minHumidity->timestamp] : null,
+        ]);
+    }
+
+    public function prediction()
+    {
+        $logs = WeatherLog::orderByDesc('timestamp')->limit(6)->get();
+        if ($logs->isEmpty()) {
+            return response()->json([]);
+        }
+        return response()->json([
+            'temperature' => round($logs->avg('temperature'), 1),
+            'humidity' => round($logs->avg('humidity')),
+            'pressure' => round($logs->avg('pressure')),
+            'precipitation' => round($logs->avg('precipitation'), 1),
+        ]);
+    }
+
+    public function chart(Request $request)
+    {
+        $type = $request->input('type', 'temperature');
+        $period = (int) $request->input('period', 30);
+        $start = now()->subDays($period);
+
+        $logs = WeatherLog::where('timestamp', '>=', $start)
+            ->orderBy('timestamp')
+            ->get()
+            ->groupBy(fn($l) => Carbon::parse($l->timestamp)->format('Y-m-d'));
+
+        $data = [];
+        foreach ($logs as $date => $items) {
+            $data[] = [
+                'date' => $date,
+                'value' => round($items->avg($type), 2),
+            ];
+        }
+
+        return response()->json($data);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,10 @@
     "": {
       "dependencies": {
         "@vitejs/plugin-vue": "^5.2.4",
+        "chart.js": "^4.4.1",
         "pinia": "^3.0.3",
         "vue": "^3.5.17",
+        "vue-grid-layout": "^2.4.0",
         "vue-router": "^4.5.1"
       },
       "devDependencies": {
@@ -599,6 +601,231 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@interactjs/actions": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/actions/-/actions-1.10.2.tgz",
+      "integrity": "sha512-BHJcW84WCMf/LsKmha/1Yog7aH3+QBXbLvowvZvwYvgjdUIb3xCa1a7FUYXuWAeKNMyKPVjFun+WPce75B+1tA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@interactjs/interact": "1.10.2"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.2",
+        "@interactjs/utils": "1.10.2"
+      }
+    },
+    "node_modules/@interactjs/arrange": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/arrange/-/arrange-1.10.2.tgz",
+      "integrity": "sha512-pPLA9o4RWMFN0VfalklOFSRLL4WqqXcD9no4XEuqV00goZPCxLBbMTztaWwnutlRy7evtOhUjUH+pZVsS+dZ4Q==",
+      "license": "MIT"
+    },
+    "node_modules/@interactjs/auto-scroll": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/auto-scroll/-/auto-scroll-1.10.2.tgz",
+      "integrity": "sha512-yYqzOawwvWd1NNnlqZdzrXoOMFafQ2/ws85erpJqdaNMQE221z2uP+QYhFRLQRgYUlTbHFfmjDpzhuJgq4uA8Q==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@interactjs/interact": "1.10.2"
+      },
+      "peerDependencies": {
+        "@interactjs/utils": "1.10.2"
+      }
+    },
+    "node_modules/@interactjs/auto-start": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/auto-start/-/auto-start-1.10.2.tgz",
+      "integrity": "sha512-nZudj8VzJzz+uEyDHqXwtKpvUYr+Oj1+xBrJEu21CywroHQWM2J4fCIiCgeCo3d5/p/TrzFk5b+YfAWePKiLxA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@interactjs/interact": "1.10.2"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.2",
+        "@interactjs/utils": "1.10.2"
+      }
+    },
+    "node_modules/@interactjs/clone": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/clone/-/clone-1.10.2.tgz",
+      "integrity": "sha512-XzA8BRHSCwvysOegZ1kopg+IJF3erh4qzY6DRoZsIJovKAXawoa176E58IAzDbgYPJ2yoaSGT+XyzT2C0wa3pQ==",
+      "license": "MIT"
+    },
+    "node_modules/@interactjs/core": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/core/-/core-1.10.2.tgz",
+      "integrity": "sha512-SA5KRGo+gFJOhBj1Z2dLHhAf0/2nyHNd4SQ460aIQ3jj/QhqbJW6kGzmh7hBa2FzVGgxLhcQu7NZaP4rnDfUNw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@interactjs/utils": "1.10.2"
+      }
+    },
+    "node_modules/@interactjs/dev-tools": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/dev-tools/-/dev-tools-1.10.2.tgz",
+      "integrity": "sha512-aAd9NgTAGA3yVdFCYcAAYrM4TYQFuVqEvsF+xj+g5SlGyrJ7+GTjPZ2rScOyAsABY4Tz64L2pXvWmXMG87dncA==",
+      "license": "MIT",
+      "dependencies": {
+        "@interactjs/utils": "1.10.2"
+      },
+      "optionalDependencies": {
+        "@interactjs/interact": "1.10.2"
+      }
+    },
+    "node_modules/@interactjs/feedback": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/feedback/-/feedback-1.10.2.tgz",
+      "integrity": "sha512-XlcoICGrFeUwwRtDgOpstOOvlU42WZoEg7gJHK3LwF7j0IctPd1+3blXofFlBeVvodle8MvUMepm5CRXz741fA==",
+      "license": "MIT"
+    },
+    "node_modules/@interactjs/inertia": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/inertia/-/inertia-1.10.2.tgz",
+      "integrity": "sha512-ZmN1joN6J36Q6SOp3V0iZOisXZOBMSAUj0STo8wbwCKy7K8IrC9vjUBbO2JM52cT6o7hg5ebHsp5c8FrebSHlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@interactjs/offset": "1.10.2"
+      },
+      "optionalDependencies": {
+        "@interactjs/interact": "1.10.2"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.2",
+        "@interactjs/modifiers": "1.10.2",
+        "@interactjs/utils": "1.10.2"
+      }
+    },
+    "node_modules/@interactjs/interact": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/interact/-/interact-1.10.2.tgz",
+      "integrity": "sha512-Ms5uVCY9IobVYpQyBnBdkP6Bk6iDY7TkC7GupsdUPUxzAvYSQCTEAGr/1PwxSrSS6dN/8O8TuyUWPbCaylr/JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@interactjs/core": "1.10.2",
+        "@interactjs/types": "1.10.2",
+        "@interactjs/utils": "1.10.2"
+      }
+    },
+    "node_modules/@interactjs/interactjs": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/interactjs/-/interactjs-1.10.2.tgz",
+      "integrity": "sha512-OwLl70af6lfZOOg/bvWKSNm1DS1nDI72QnzDYljSKfc2D8stqLIGDO1wPY2rhZudUG5q3t50EhmMUQF76yll/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@interactjs/actions": "1.10.2",
+        "@interactjs/arrange": "1.10.2",
+        "@interactjs/auto-scroll": "1.10.2",
+        "@interactjs/auto-start": "1.10.2",
+        "@interactjs/clone": "1.10.2",
+        "@interactjs/core": "1.10.2",
+        "@interactjs/dev-tools": "1.10.2",
+        "@interactjs/feedback": "1.10.2",
+        "@interactjs/inertia": "1.10.2",
+        "@interactjs/interact": "1.10.2",
+        "@interactjs/modifiers": "1.10.2",
+        "@interactjs/multi-target": "1.10.2",
+        "@interactjs/offset": "1.10.2",
+        "@interactjs/pointer-events": "1.10.2",
+        "@interactjs/react": "1.10.2",
+        "@interactjs/reflow": "1.10.2",
+        "@interactjs/utils": "1.10.2",
+        "@interactjs/vue": "1.10.2"
+      }
+    },
+    "node_modules/@interactjs/modifiers": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/modifiers/-/modifiers-1.10.2.tgz",
+      "integrity": "sha512-3wYEucvZF2NTIslnVIKw5MWhkn9LM42cGCQaC19o3LZeWnbps7NnHJCyQp6zylJrCbwt7f+CSt4Oj2/s0f6XEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@interactjs/snappers": "1.10.2"
+      },
+      "optionalDependencies": {
+        "@interactjs/interact": "1.10.2"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.2",
+        "@interactjs/utils": "1.10.2"
+      }
+    },
+    "node_modules/@interactjs/multi-target": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/multi-target/-/multi-target-1.10.2.tgz",
+      "integrity": "sha512-O2GiIqgZBzjAVTOpL8doTnAcM9AtM3+H/Bb+An12wWKtNutVK7JbqUAO2nYueOk55/PP3yDLY9Qdr15RJns3lQ==",
+      "license": "MIT"
+    },
+    "node_modules/@interactjs/offset": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/offset/-/offset-1.10.2.tgz",
+      "integrity": "sha512-xLgQqinFUY7ZqSX9d9on7XRcxvQdHNEAktj2QFwxMsEwrA6zbKROpPVwt8WQ1yBAeJSFjgYGcmCMPW5K41dT0w==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@interactjs/interact": "1.10.2"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.2",
+        "@interactjs/utils": "1.10.2"
+      }
+    },
+    "node_modules/@interactjs/pointer-events": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/pointer-events/-/pointer-events-1.10.2.tgz",
+      "integrity": "sha512-O8s3N399hkGIzWGlcJVy0LJyDn5YWDh6XKjyowh/QivtlZSWPY8eglmlN2uZX0lmiqUYghbKI4CpQYP/cE0ZDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@interactjs/interact": "1.10.2"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.2",
+        "@interactjs/utils": "1.10.2"
+      }
+    },
+    "node_modules/@interactjs/react": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/react/-/react-1.10.2.tgz",
+      "integrity": "sha512-JXzPdANft+W2vq3SCSzprCwom5UuC8TaiAAhVdt8R+/P6xHbOeAX93XLS5YmDwT8e0Zh9J9jYvz55tkTdwjFZQ==",
+      "license": "MIT"
+    },
+    "node_modules/@interactjs/reflow": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/reflow/-/reflow-1.10.2.tgz",
+      "integrity": "sha512-pc6o6RRhSCYQC4auZexRb7z5FQkdSVev5HzlRfUAjfw4C076qgbcs63ESRKy4YXdSBtUTvARQZxpuWUNGquzJw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@interactjs/interact": "1.10.2"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.2",
+        "@interactjs/utils": "1.10.2"
+      }
+    },
+    "node_modules/@interactjs/snappers": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/snappers/-/snappers-1.10.2.tgz",
+      "integrity": "sha512-wQ41Vn5GRn6VavjIEUtTkd9d5QgdKgC4+CPW0fjKkiQclLBmaic7VibNETO8twN0Jx5e73EoPj9K2nAVHIA0hA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@interactjs/utils": "1.10.2"
+      }
+    },
+    "node_modules/@interactjs/types": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/types/-/types-1.10.2.tgz",
+      "integrity": "sha512-l0T1bU8OHRv716ztQOYwP+K7b/lA76C0T3r/cdabbUv6CKeAFdFRRFlmNxYOM36SxMGWAiq5VWrN3SeXlB7Fow==",
+      "license": "MIT"
+    },
+    "node_modules/@interactjs/utils": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/utils/-/utils-1.10.2.tgz",
+      "integrity": "sha512-sOr+pu7XGAN4qv+ikajMo3RJygbkbMLegmx0Tv5Qf6e80sF42FjkmHeMGuV7fL98nwat0VmDiWerOFBnKctXow==",
+      "license": "MIT"
+    },
+    "node_modules/@interactjs/vue": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@interactjs/vue/-/vue-1.10.2.tgz",
+      "integrity": "sha512-msLdc42DFsCPQZt6YBGZrw8Ro23kQcNnj+iLz2OUQcOrp/lma7WjorUuAwwfyFna2DevLtiYlMLbT0dpO/cVhg==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -649,6 +876,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1483,6 +1716,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/batch-processor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
+      "integrity": "sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==",
+      "license": "MIT"
+    },
     "node_modules/birpc": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.4.0.tgz",
@@ -1562,6 +1801,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chownr": {
@@ -1775,6 +2026,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/element-resize-detector": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.2.4.tgz",
+      "integrity": "sha512-Fl5Ftk6WwXE0wqCgNoseKWndjzZlDCwuPTcoVZfCP9R3EHQF8qUtr3YUPNETegRBOKqQKPW3n4kiIWngGi8tKg==",
+      "license": "MIT",
+      "dependencies": {
+        "batch-processor": "1.0.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -3888,6 +4148,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/vue-grid-layout": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/vue-grid-layout/-/vue-grid-layout-2.4.0.tgz",
+      "integrity": "sha512-MRQVt1BdWDaPN4gKGEKOVVwiTyucqJhrGEyjiY9Muor+dzFFq4Hm0geSpYJpLvC1GLlTL8KWUwy0suKrHm+mqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@interactjs/actions": "1.10.2",
+        "@interactjs/auto-scroll": "1.10.2",
+        "@interactjs/auto-start": "1.10.2",
+        "@interactjs/dev-tools": "1.10.2",
+        "@interactjs/interactjs": "1.10.2",
+        "@interactjs/modifiers": "1.10.2",
+        "element-resize-detector": "^1.2.1"
       }
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@vitejs/plugin-vue": "^5.2.4",
     "pinia": "^3.0.3",
     "vue": "^3.5.17",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "vue-grid-layout": "^2.4.0",
+    "chart.js": "^4.4.1"
   }
 }

--- a/resources/js/App.vue
+++ b/resources/js/App.vue
@@ -1,6 +1,12 @@
 <template>
-  <router-view />
+  <div class="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
+    <MainNavigation />
+    <div class="flex-1">
+      <router-view />
+    </div>
+  </div>
 </template>
 
 <script setup>
+import MainNavigation from './components/MainNavigation.vue';
 </script>

--- a/resources/js/components/DashboardPage.vue
+++ b/resources/js/components/DashboardPage.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="p-4">
+    <GridLayout
+      :layout="layout"
+      :col-num="12"
+      :row-height="30"
+      :is-draggable="true"
+      :is-resizable="true"
+      @layout-updated="saveLayout"
+      class="layout">
+      <GridItem v-for="item in layout" :key="item.i" :x="item.x" :y="item.y" :w="item.w" :h="item.h" :i="item.i">
+        <component :is="getWidget(item.i)" class="h-full" />
+      </GridItem>
+    </GridLayout>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { GridLayout, GridItem } from 'vue-grid-layout';
+import WidgetTemperature from './WidgetTemperature.vue';
+import WidgetGraph from './WidgetGraph.vue';
+import WidgetTable from './WidgetTable.vue';
+import WidgetPrediction from './WidgetPrediction.vue';
+
+const defaultLayout = [
+  { i: 'temp', x: 0, y: 0, w: 4, h: 3 },
+  { i: 'graph', x: 4, y: 0, w: 8, h: 4 },
+  { i: 'table', x: 0, y: 3, w: 4, h: 4 },
+  { i: 'predict', x: 4, y: 4, w: 8, h: 3 },
+];
+
+const layout = ref([]);
+
+function getWidget(name) {
+  switch (name) {
+    case 'temp':
+      return WidgetTemperature;
+    case 'graph':
+      return WidgetGraph;
+    case 'table':
+      return WidgetTable;
+    case 'predict':
+      return WidgetPrediction;
+  }
+}
+
+function loadLayout() {
+  const saved = localStorage.getItem('dashboardLayout');
+  layout.value = saved ? JSON.parse(saved) : defaultLayout;
+}
+
+function saveLayout(newLayout) {
+  localStorage.setItem('dashboardLayout', JSON.stringify(newLayout));
+}
+
+onMounted(loadLayout);
+</script>
+
+<style scoped>
+.layout {
+  min-height: 80vh;
+}
+</style>

--- a/resources/js/components/MainNavigation.vue
+++ b/resources/js/components/MainNavigation.vue
@@ -1,0 +1,50 @@
+<template>
+  <nav class="bg-white/80 backdrop-blur shadow-md border-b border-gray-200">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex justify-between h-16">
+        <div class="flex">
+          <div class="-ml-2 mr-2 flex items-center md:hidden">
+            <button @click="open = !open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-700">
+              <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
+                <path v-if="!open" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                <path v-else class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+          <div class="flex-shrink-0 flex items-center">
+            <span class="font-bold text-lg">Weathy</span>
+          </div>
+          <div class="hidden md:ml-6 md:flex md:space-x-8">
+            <RouterLink to="/" class="inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium" :class="linkClass('/')">Počasí</RouterLink>
+            <RouterLink to="/dashboard" class="inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium" :class="linkClass('/dashboard')">Nástěnka</RouterLink>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div v-if="open" class="md:hidden">
+      <div class="pt-2 pb-3 space-y-1">
+        <RouterLink to="/" class="block pl-3 pr-4 py-2 border-l-4 text-base font-medium" :class="mobileLinkClass('/')">Počasí</RouterLink>
+        <RouterLink to="/dashboard" class="block pl-3 pr-4 py-2 border-l-4 text-base font-medium" :class="mobileLinkClass('/dashboard')">Nástěnka</RouterLink>
+      </div>
+    </div>
+  </nav>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useRoute, RouterLink } from 'vue-router';
+
+const open = ref(false);
+const route = useRoute();
+
+function linkClass(path) {
+  return route.path === path
+    ? 'border-indigo-500 text-gray-900'
+    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300';
+}
+function mobileLinkClass(path) {
+  return route.path === path
+    ? 'bg-indigo-50 border-indigo-500 text-indigo-700'
+    : 'border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800';
+}
+</script>

--- a/resources/js/components/WeatherApp.vue
+++ b/resources/js/components/WeatherApp.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex h-screen" id="app-root">
+  <div class="flex h-full" id="app-root">
     <aside class="w-80 bg-white/70 backdrop-blur p-4 overflow-y-auto space-y-4">
       <h1 class="text-xl font-bold mb-2">{{ trans.title }}</h1>
       <SearchLocation />

--- a/resources/js/components/WidgetGraph.vue
+++ b/resources/js/components/WidgetGraph.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 h-full flex flex-col">
+    <h3 class="text-lg font-semibold mb-2 flex items-center gap-2">Graf vývoje</h3>
+    <canvas ref="canvas" class="flex-1" />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { Chart, LineController, LineElement, PointElement, LinearScale, CategoryScale, Filler } from 'chart.js';
+
+Chart.register(LineController, LineElement, PointElement, LinearScale, CategoryScale, Filler);
+
+const canvas = ref(null);
+
+async function load() {
+  const res = await fetch('/api/dashboard/chart?type=temperature&period=30');
+  const data = await res.json();
+  const labels = data.map(d => d.date);
+  const values = data.map(d => d.value);
+  new Chart(canvas.value.getContext('2d'), {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [{
+        data: values,
+        fill: true,
+        borderColor: '#6366f1',
+        backgroundColor: 'rgba(99,102,241,0.2)',
+        tension: 0.4,
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: { y: { beginAtZero: true } }
+    }
+  });
+}
+
+onMounted(load);
+</script>

--- a/resources/js/components/WidgetPrediction.vue
+++ b/resources/js/components/WidgetPrediction.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 h-full flex flex-col">
+    <h3 class="text-lg font-semibold mb-2">Předpověď</h3>
+    <div class="flex-1" v-if="data">
+      <p>Teplota: {{ data.temperature }}°C</p>
+      <p>Vlhkost: {{ data.humidity }}%</p>
+    </div>
+    <div v-else class="flex-1 flex items-center justify-center">Načítání...</div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+
+const data = ref(null);
+async function load() {
+  const res = await fetch('/api/dashboard/prediction');
+  data.value = await res.json();
+}
+
+onMounted(load);
+</script>

--- a/resources/js/components/WidgetTable.vue
+++ b/resources/js/components/WidgetTable.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 h-full flex flex-col">
+    <h3 class="text-lg font-semibold mb-2">Tabulka extrémů</h3>
+    <table class="min-w-full text-sm" v-if="data">
+      <tbody class="divide-y divide-gray-200">
+        <tr>
+          <td class="py-1">Max. teplota</td>
+          <td class="py-1 text-right">{{ data.max_temperature.value }}°C</td>
+        </tr>
+        <tr>
+          <td class="py-1">Min. teplota</td>
+          <td class="py-1 text-right">{{ data.min_temperature.value }}°C</td>
+        </tr>
+        <tr>
+          <td class="py-1">Max. vlhkost</td>
+          <td class="py-1 text-right">{{ data.max_humidity.value }}%</td>
+        </tr>
+        <tr>
+          <td class="py-1">Min. vlhkost</td>
+          <td class="py-1 text-right">{{ data.min_humidity.value }}%</td>
+        </tr>
+      </tbody>
+    </table>
+    <div v-else class="flex-1 flex items-center justify-center">Načítání...</div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+const data = ref(null);
+
+async function load() {
+  const res = await fetch('/api/dashboard/extremes');
+  data.value = await res.json();
+}
+
+onMounted(load);
+</script>

--- a/resources/js/components/WidgetTemperature.vue
+++ b/resources/js/components/WidgetTemperature.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 h-full flex flex-col">
+    <h3 class="text-lg font-semibold mb-2 flex items-center gap-2">
+      <span>Teplotní statistiky</span>
+    </h3>
+    <div class="flex-1 space-y-2" v-if="data">
+      <p>Týdenní průměr: <strong>{{ data.week.temperature }}°C</strong></p>
+      <p>Měsíční průměr: <strong>{{ data.month.temperature }}°C</strong></p>
+    </div>
+    <div v-else class="flex-1 flex items-center justify-center">Načítání...</div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+
+const data = ref(null);
+
+async function load() {
+  const res = await fetch('/api/dashboard/summary');
+  data.value = await res.json();
+}
+
+onMounted(load);
+</script>

--- a/resources/js/router.js
+++ b/resources/js/router.js
@@ -1,8 +1,10 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import WeatherApp from './components/WeatherApp.vue';
+import DashboardPage from './components/DashboardPage.vue';
 
 const routes = [
-  { path: '/', component: WeatherApp }
+  { path: '/', component: WeatherApp },
+  { path: '/dashboard', component: DashboardPage }
 ];
 
 export default createRouter({

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,10 +3,19 @@
 use Illuminate\Support\Facades\Route;
 
 use App\Http\Controllers\WeatherController;
+use App\Http\Controllers\DashboardController;
 
 Route::get('/', [WeatherController::class, 'index']);
+Route::get('/dashboard', [WeatherController::class, 'index']);
 Route::get('/api/weather', [WeatherController::class, 'getWeather']);
 Route::get('/api/forecast', [WeatherController::class, 'getForecast']);
 Route::get('/api/combined', [WeatherController::class, 'combined']);
 Route::get('/api/stats', [WeatherController::class, 'stats']);
 Route::get('/api/predict', [WeatherController::class, 'predict']);
+
+Route::prefix('api/dashboard')->group(function () {
+    Route::get('/summary', [DashboardController::class, 'summary']);
+    Route::get('/extremes', [DashboardController::class, 'extremes']);
+    Route::get('/prediction', [DashboardController::class, 'prediction']);
+    Route::get('/chart', [DashboardController::class, 'chart']);
+});

--- a/tests/Feature/DashboardSummaryTest.php
+++ b/tests/Feature/DashboardSummaryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\WeatherLog;
+
+class DashboardSummaryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_summary_returns_data()
+    {
+        WeatherLog::create([
+            'temperature' => 10,
+            'humidity' => 50,
+            'wind_speed' => 1,
+            'pressure' => 1000,
+            'precipitation' => 0,
+            'lat' => 1,
+            'lon' => 1,
+            'source' => 'test',
+            'timestamp' => now(),
+        ]);
+
+        $response = $this->get('/api/dashboard/summary');
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['week' => ['temperature'], 'month' => ['temperature']]);
+    }
+}


### PR DESCRIPTION
## Summary
- create `DashboardController` with API endpoints
- expose dashboard routes in `web.php`
- add responsive `MainNavigation` component
- add draggable `DashboardPage` with widgets
- integrate new navigation into `App.vue`
- update router and weather page layout
- install `vue-grid-layout` and `chart.js`
- add feature test for dashboard summary

## Testing
- `composer install`
- `npm install`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_687429e9ea00832ab6b95ab3cb23d2bd